### PR TITLE
Fix msvc build

### DIFF
--- a/ngx_http_upload_module.c
+++ b/ngx_http_upload_module.c
@@ -1355,7 +1355,7 @@ static ngx_int_t ngx_http_upload_body_handler(ngx_http_request_t *r) { /* {{{ */
     r->main->count--;
 #endif
 
-    if(uri.len != 0 && uri.data[0] == '/') {
+    if(uri.len == 0 || uri.data[0] != '@') {
         rc = ngx_http_internal_redirect(r, &uri, &args);
     }
     else{

--- a/ngx_http_upload_module.c
+++ b/ngx_http_upload_module.c
@@ -18,7 +18,9 @@ typedef ngx_md5_t MD5_CTX;
 #define MD5Update ngx_md5_update
 #define MD5Final ngx_md5_final
 
+#ifndef MD5_DIGEST_LENGTH
 #define MD5_DIGEST_LENGTH 16
+#endif
 
 #include <openssl/sha.h>
 
@@ -44,6 +46,19 @@ typedef ngx_md5_t MD5_CTX;
 
 
 #endif
+
+#ifdef _MSC_VER 
+  #define strncasecmp _strnicmp
+
+  static ngx_inline void
+  ftruncate(ngx_fd_t fd, off_t file_pos) {
+    LARGE_INTEGER li;
+    li.QuadPart = file_pos;
+    SetFilePointerEx(fd, li, &li, FILE_BEGIN);
+    SetEndOfFile(fd);
+  }
+#endif
+
 
 #define MULTIPART_FORM_DATA_STRING              "multipart/form-data"
 #define BOUNDARY_STRING                         "boundary="


### PR DESCRIPTION
* fixes build with msvc (missing `ftruncate`, `strncasecmp`)
* named location starts with `@` only (don't segfault on empty location)
* suppress warnings, several small nginx and toolchain compatibility tweaks and code simplification
